### PR TITLE
Update HAPI to the Latest v5 Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <common-ldmclient.version>6.1.0</common-ldmclient.version>
-        <hapi-fhir-structures-r4.version>5.5.1</hapi-fhir-structures-r4.version>
+        <hapi-fhir-structures-r4.version>5.7.9</hapi-fhir-structures-r4.version>
         <httpclient.version>4.5.13</httpclient.version>
         <mockito-core.version>4.8.0</mockito-core.version>
         <junit-jupiter-api.version>5.9.1</junit-jupiter-api.version>


### PR DESCRIPTION
The v6 Version seems to be incompatible with Java 8.